### PR TITLE
Fix: Prevent validation on AddUser Cancel button

### DIFF
--- a/Members/Areas/Identity/Pages/AddUser.cshtml
+++ b/Members/Areas/Identity/Pages/AddUser.cshtml
@@ -152,7 +152,7 @@
                     <div class="d-flex justify-content-center mt-3">
 
                         <!-- Cancel Button -->
-                        <button type="submit" asp-page-handler="Cancel" class="btn btn-sm btn-secondary me-2">
+                        <button type="button" onclick="window.location.href='/Identity/Users'" class="btn btn-sm btn-secondary me-2">
                             <i class="bi bi-box-arrow-left"></i> Cancel
                         </button>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Members",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Changed the Cancel button on the AddUser page from type="submit" to type="button" and added an onclick event to handle redirection. This prevents client-side validation from blocking the cancel action when required fields are empty.