### PR TITLE
Add copy button for authenticator key

### DIFF
--- a/Members/Areas/Identity/Pages/Account/Manage/EnableAuthenticator.cshtml
+++ b/Members/Areas/Identity/Pages/Account/Manage/EnableAuthenticator.cshtml
@@ -19,7 +19,8 @@
         </li>
         <li class="text-gold-darker my-3 text-start">
             <span>Scan the QR Code or enter this key</span> <span>into your two factor authenticator app.</span><br /><br />
-            <kbd>@Model.SharedKey</kbd>
+            <kbd id="sharedKey">@Model.SharedKey</kbd>
+            <button id="copyKeyButton" class="btn btn-sm btn-success my-2 ms-2" type="button">Copy</button>
             <div class="my-4 text-center" id="qrCode"></div>
             <div id="qrCodeData" data-url="@Model.AuthenticatorUri"></div>
         </li>
@@ -48,4 +49,26 @@
     <partial name="_ValidationScriptsPartial" />
     <script type="text/javascript" src="~/lib/qrcodes/qrcode.js"></script>
     <script type="text/javascript" src="~/js/qr.js"></script>
+    <script type="text/javascript">
+        document.addEventListener('DOMContentLoaded', function () {
+            var copyKeyButton = document.getElementById('copyKeyButton');
+            var sharedKeyElement = document.getElementById('sharedKey');
+
+            if (copyKeyButton && sharedKeyElement) {
+                copyKeyButton.addEventListener('click', function () {
+                    var keyToCopy = sharedKeyElement.innerText;
+                    navigator.clipboard.writeText(keyToCopy).then(function () {
+                        var originalButtonText = copyKeyButton.innerText;
+                        copyKeyButton.innerText = 'Copied!';
+                        setTimeout(function () {
+                            copyKeyButton.innerText = originalButtonText;
+                        }, 2000); // Change back after 2 seconds
+                    }).catch(function (err) {
+                        console.error('Failed to copy text: ', err);
+                        // Optionally, display an error message to the user
+                    });
+                });
+            }
+        });
+    </script>
 }


### PR DESCRIPTION
Added a 'Copy' button to the EnableAuthenticator page to allow users to easily copy the shared key for their authenticator app.

- Added button HTML to EnableAuthenticator.cshtml
- Added JavaScript for copy-to-clipboard functionality
- Styled button with Bootstrap classes and adjusted margins for better responsiveness.