### PR TITLE
feat: Add database seeding for color variables

### DIFF
--- a/Members/Areas/Admin/Pages/ColorManagement.cshtml.cs
+++ b/Members/Areas/Admin/Pages/ColorManagement.cshtml.cs
@@ -26,18 +26,22 @@ namespace Members.Areas.Admin.Pages
             ColorVars = await _context.ColorVars.ToListAsync();
         }
 
-        public async Task<IActionResult> OnPostAsync(Dictionary<string, string> colors)
+        public async Task<IActionResult> OnPostAsync()
         {
-            foreach (var color in colors)
+            foreach (var key in Request.Form.Keys)
             {
-                var colorVar = await _context.ColorVars.FirstOrDefaultAsync(c => c.Name == color.Key);
-                if (colorVar != null)
+                if (key.StartsWith("colors["))
                 {
-                    colorVar.Value = color.Value;
-                }
-                else
-                {
-                    _context.ColorVars.Add(new ColorVar { Name = color.Key, Value = color.Value });
+                    var name = key.Substring(7, key.Length - 8);
+                    var colorVar = await _context.ColorVars.FirstOrDefaultAsync(c => c.Name == name);
+                    if (colorVar != null)
+                    {
+                        colorVar.Value = Request.Form[key]!;
+                    }
+                    else
+                    {
+                        _context.ColorVars.Add(new ColorVar { Name = name, Value = Request.Form[key]! });
+                    }
                 }
             }
 

--- a/Members/Data/ColorVarSeeder.cs
+++ b/Members/Data/ColorVarSeeder.cs
@@ -1,0 +1,35 @@
+using Members.Data;
+using Members.Models;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Members.Data
+{
+    public static class ColorVarSeeder
+    {
+        public static async Task SeedAsync(ApplicationDbContext context, string cssFilePath)
+        {
+            if (context.ColorVars.Any())
+            {
+                return; // DB has been seeded
+            }
+
+            var cssContent = await System.IO.File.ReadAllTextAsync(cssFilePath);
+            var regex = new Regex(@"--(?<name>[\w-]+):\s*(?<value>#[\da-fA-F]{3,6});");
+            var matches = regex.Matches(cssContent);
+
+            foreach (Match match in matches)
+            {
+                var name = match.Groups["name"].Value;
+                var value = match.Groups["value"].Value;
+
+                context.ColorVars.Add(new ColorVar { Name = name, Value = value });
+            }
+
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/Members/Program.cs
+++ b/Members/Program.cs
@@ -167,4 +167,20 @@ using (var scope = app.Services.CreateScope())
     }
 }
 
+using (var scope = app.Services.CreateScope())
+{
+    var services = scope.ServiceProvider;
+    try
+    {
+        var context = services.GetRequiredService<Members.Data.ApplicationDbContext>();
+        var cssPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "css", "site-colors.css");
+        Members.Data.ColorVarSeeder.SeedAsync(context, cssPath).Wait();
+    }
+    catch (Exception ex)
+    {
+        var logger = services.GetRequiredService<ILogger<Program>>();
+        logger.LogError(ex, "An error occurred while seeding the database.");
+    }
+}
+
 app.Run();


### PR DESCRIPTION
This commit introduces a database seeding mechanism to populate the `ColorVars` table with default values from the `site-colors.css` file. This ensures that the color management page is functional out of the box.

The following changes were made:

*   **Database Seeding:**
    *   A new `ColorVarSeeder` class was created to read the colors from `site-colors.css` and populate the `ColorVars` table.
    *   The `Program.cs` file was modified to call the seeder when the application starts.

*   **Color Management Page:**
    *   The `ColorManagement.cshtml.cs` file was updated to correctly handle the case where there are no colors in the database.
    *   The `OnPostAsync` method was fixed to correctly update the colors.

*   **Bug Fixes:**
    *   Fixed a build error caused by an ambiguous reference to the `File` class.
    *   Fixed a build error caused by an incorrect iteration over `Request.Form`.
    *   Fixed several null reference warnings.