### PR TITLE
fix: Correctly parse CSS variables in database seeder

### DIFF
--- a/Members/Data/ColorVarSeeder.cs
+++ b/Members/Data/ColorVarSeeder.cs
@@ -18,7 +18,7 @@ namespace Members.Data
             }
 
             var cssContent = await System.IO.File.ReadAllTextAsync(cssFilePath);
-            var regex = new Regex(@"--(?<name>[\w-]+):\s*(?<value>#[\da-fA-F]{3,6});");
+            var regex = new Regex(@"--(?<name>[\w-]+)\s*:\s*(?<value>[^;)]+)(?=[;\)])");
             var matches = regex.Matches(cssContent);
 
             foreach (Match match in matches)


### PR DESCRIPTION
This commit fixes a bug in the `ColorVarSeeder` that caused it to incorrectly parse CSS variables with fallback values. The regex has been updated to correctly handle these cases.

The following changes were made:

*   **ColorVarSeeder:**
    *   Updated the regex to correctly parse CSS variables with fallback values.