### PR TITLE
fix: Resolve 404 error and add logging to seeder

### DIFF
--- a/Members/Program.cs
+++ b/Members/Program.cs
@@ -170,15 +170,17 @@ using (var scope = app.Services.CreateScope())
 using (var scope = app.Services.CreateScope())
 {
     var services = scope.ServiceProvider;
+    var logger = services.GetRequiredService<ILogger<Program>>();
     try
     {
+        logger.LogInformation("Seeding database...");
         var context = services.GetRequiredService<Members.Data.ApplicationDbContext>();
         var cssPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "css", "site-colors.css");
         Members.Data.ColorVarSeeder.SeedAsync(context, cssPath).Wait();
+        logger.LogInformation("Database seeding complete.");
     }
     catch (Exception ex)
     {
-        var logger = services.GetRequiredService<ILogger<Program>>();
         logger.LogError(ex, "An error occurred while seeding the database.");
     }
 }

--- a/Members/wwwroot/css/dynamic-colors.css
+++ b/Members/wwwroot/css/dynamic-colors.css
@@ -1,0 +1,1 @@
+/* This file is intentionally left empty. The styles are injected dynamically by the javascript. */


### PR DESCRIPTION
This commit resolves a 404 error for the `dynamic-colors.css` file by creating an empty file at the specified location. It also adds logging to the database seeder to help diagnose any issues with the seeding process.

The following changes were made:

*   **dynamic-colors.css:**
    *   Created an empty `dynamic-colors.css` file to resolve the 404 error.

*   **Program.cs:**
    *   Added logging to the database seeder to help diagnose any issues with the seeding process.