### PR TITLE
fix: Populate color pickers on admin page

### DIFF
--- a/Members/Areas/Admin/Pages/ColorManagement.cshtml
+++ b/Members/Areas/Admin/Pages/ColorManagement.cshtml
@@ -28,3 +28,7 @@
         </div>
     </form>
 </div>
+
+@section Scripts {
+    <script src="~/js/color-management.js" asp-append-version="true"></script>
+}

--- a/Members/wwwroot/js/color-management.js
+++ b/Members/wwwroot/js/color-management.js
@@ -1,0 +1,12 @@
+(function () {
+    fetch('/api/colors')
+        .then(response => response.json())
+        .then(colors => {
+            for (const [key, value] of Object.entries(colors)) {
+                const input = document.querySelector(`input[name="colors[${key}]"]`);
+                if (input) {
+                    input.value = value;
+                }
+            }
+        });
+})();


### PR DESCRIPTION
This commit fixes a bug where the color pickers on the admin page were not being populated with the colors from the database. A new javascript file has been created to handle this functionality.

The following changes were made:

*   **color-management.js:**
    *   A new javascript file was created to fetch the colors from the API and populate the color pickers on the admin page.

*   **ColorManagement.cshtml:**
    *   The `ColorManagement.cshtml` file was modified to include the new `color-management.js` file.