### PR TITLE
fix: Correctly parse CSS variables in database seeder

### DIFF
--- a/Members/Data/ColorVarSeeder.cs
+++ b/Members/Data/ColorVarSeeder.cs
@@ -18,7 +18,7 @@ namespace Members.Data
             }
 
             var cssContent = await System.IO.File.ReadAllTextAsync(cssFilePath);
-            var regex = new Regex(@"--(?<name>[\w-]+)\s*:\s*(?<value>[^;)]+)(?=[;\)])");
+            var regex = new Regex(@"--(?<name>[\w-]+)\s*,\s*(?<value>#[0-9a-fA-F]{3,6})\)");
             var matches = regex.Matches(cssContent);
 
             foreach (Match match in matches)

--- a/Members/wwwroot/js/dynamic-colors.js
+++ b/Members/wwwroot/js/dynamic-colors.js
@@ -4,7 +4,7 @@
         .then(colors => {
             const style = document.createElement('style');
             style.innerHTML = `:root {
-${Object.entries(colors).map(([key, value]) => `    --${key}: ${value};`).join('\n')}
+                ${Object.entries(colors).map(([key, value]) => `    --${key}: ${value};`).join('\n')}
             }`;
             document.head.appendChild(style);
         });


### PR DESCRIPTION
This commit fixes a bug in the `ColorVarSeeder` that caused it to incorrectly parse CSS variables with fallback values. The regex has been updated to correctly handle these cases.

The following changes were made:

*   **ColorVarSeeder:**
    *   Updated the regex to correctly parse CSS variables with fallback values.
*   **dynamic-colors.js**
    *   Updated the javascript to correctly format the CSS variables.