### PR TITLE
fix: Correctly process form data on color management page

### DIFF
--- a/Members/Areas/Admin/Pages/ColorManagement.cshtml.cs
+++ b/Members/Areas/Admin/Pages/ColorManagement.cshtml.cs
@@ -27,25 +27,20 @@ namespace Members.Areas.Admin.Pages
             ColorVars = await _context.ColorVars.ToListAsync();
         }
 
-        public async Task<IActionResult> OnPostAsync()
+        public async Task<IActionResult> OnPostAsync(Dictionary<string, string> colors)
         {
-            foreach (var key in Request.Form.Keys)
+            foreach (var color in colors)
             {
-                if (key.StartsWith("colors["))
+                if (Regex.IsMatch(color.Value, @"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"))
                 {
-                    var name = key.Substring(7, key.Length - 8);
-                    var value = Request.Form[key];
-                    if (Regex.IsMatch(value, @"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"))
+                    var colorVar = await _context.ColorVars.FirstOrDefaultAsync(c => c.Name == color.Key);
+                    if (colorVar != null)
                     {
-                        var colorVar = await _context.ColorVars.FirstOrDefaultAsync(c => c.Name == name);
-                        if (colorVar != null)
-                        {
-                            colorVar.Value = value;
-                        }
-                        else
-                        {
-                            _context.ColorVars.Add(new ColorVar { Name = name, Value = value });
-                        }
+                        colorVar.Value = color.Value;
+                    }
+                    else
+                    {
+                        _context.ColorVars.Add(new ColorVar { Name = color.Key, Value = color.Value });
                     }
                 }
             }


### PR DESCRIPTION
This commit fixes a bug where the color management page was throwing a 400 error when saving changes. The `OnPostAsync` method has been updated to correctly process the form data by letting ASP.NET Core handle the model binding.

The following changes were made:

*   **ColorManagement.cshtml.cs:**
    *   Updated the `OnPostAsync` method to correctly process the form data.