### PR TITLE
fix: Add antiforgery token to color management form

### DIFF
--- a/Members/Areas/Admin/Pages/ColorManagement.cshtml
+++ b/Members/Areas/Admin/Pages/ColorManagement.cshtml
@@ -9,6 +9,7 @@
 
 <div class="card m-1 p-2 shadow">
     <form method="post">
+        @Html.AntiForgeryToken()
         <div class="row">
             @if (Model.ColorVars != null)
             {


### PR DESCRIPTION
This commit fixes a bug where the color management page was throwing a 400 error when saving changes. The error was caused by a missing antiforgery token. The token has now been added to the form.

The following changes were made:

*   **ColorManagement.cshtml:**
    *   Added the antiforgery token to the form.