### PR TITLE
fix: Correctly parse CSS variables in database seeder

### DIFF
--- a/Members/Data/ColorVarSeeder.cs
+++ b/Members/Data/ColorVarSeeder.cs
@@ -13,7 +13,7 @@ namespace Members.Data
         public static async Task SeedAsync(ApplicationDbContext context, string cssFilePath)
         {
             var cssContent = await System.IO.File.ReadAllTextAsync(cssFilePath);
-            var regex = new Regex(@"--(?<name>[\w-]+)\s*:\s*(?<value>#[0-9a-fA-F]{3,6})");
+            var regex = new Regex(@"--(?<name>[\w-]+)\s*,\s*(?<value>#[0-9a-fA-F]{3,6})\)");
             var matches = regex.Matches(cssContent);
 
             Console.WriteLine($"Found {matches.Count} matches in css file.");


### PR DESCRIPTION
This commit fixes a bug in the `ColorVarSeeder` that caused it to incorrectly parse CSS variables. The regex has been updated to correctly handle CSS variables that are defined within a `var()` function.

The following changes were made:

*   **ColorVarSeeder:**
    *   Updated the regex to correctly parse CSS variables that are defined within a `var()` function.