### PR TITLE
fix: Correctly handle -- prefix for color variables

### DIFF
--- a/Members/Areas/Admin/Pages/ColorManagement.cshtml.cs
+++ b/Members/Areas/Admin/Pages/ColorManagement.cshtml.cs
@@ -33,15 +33,14 @@ namespace Members.Areas.Admin.Pages
             {
                 if (Regex.IsMatch(color.Value, @"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"))
                 {
-                    var name = "--" + color.Key;
-                    var colorVar = await _context.ColorVars.FirstOrDefaultAsync(c => c.Name == name);
+                    var colorVar = await _context.ColorVars.FirstOrDefaultAsync(c => c.Name == color.Key);
                     if (colorVar != null)
                     {
                         colorVar.Value = color.Value;
                     }
                     else
                     {
-                        _context.ColorVars.Add(new ColorVar { Name = name, Value = color.Value });
+                        _context.ColorVars.Add(new ColorVar { Name = color.Key, Value = color.Value });
                     }
                 }
             }

--- a/Members/Data/ColorVarSeeder.cs
+++ b/Members/Data/ColorVarSeeder.cs
@@ -19,7 +19,7 @@ namespace Members.Data
             Console.WriteLine($"Found {matches.Count} matches in css file.");
             foreach (Match match in matches)
             {
-                var name = "--" + match.Groups["name"].Value;
+                var name = match.Groups["name"].Value;
                 var value = match.Groups["value"].Value;
 
                 if (!context.ColorVars.Any(c => c.Name == name))


### PR DESCRIPTION
This commit fixes a bug where the `--` prefix was being duplicated for color variables. The `ColorVarSeeder` and `ColorManagement.cshtml.cs` files have been updated to correctly handle the `--` prefix.

The following changes were made:

*   **ColorVarSeeder.cs:**
    *   Updated the seeder to not add the `--` prefix when adding new color variables to the database.

*   **ColorManagement.cshtml.cs:**
    *   Updated the `OnPostAsync` method to not add the `--` prefix when saving changes.