### PR TITLE
fix: Correctly format CSS variables in javascript

### DIFF
--- a/Members/wwwroot/js/dynamic-colors.js
+++ b/Members/wwwroot/js/dynamic-colors.js
@@ -4,7 +4,7 @@
         .then(colors => {
             let css = ':root {\n';
             for (const [key, value] of Object.entries(colors)) {
-                css += `    ${key}: ${value};\n`;
+                css += `    --${key}: ${value};\n`;
             }
             css += '}';
             const style = document.createElement('style');


### PR DESCRIPTION
This commit fixes a bug where the CSS variables were not being correctly formatted in the javascript file. The `--` prefix was missing. This has now been fixed.

The following changes were made:

*   **dynamic-colors.js:**
    *   Updated the javascript to correctly format the CSS variables with the `--` prefix.