### PR TITLE
fix: Handle duplicate keys in ColorsController

### DIFF
--- a/Members/Controllers/ColorsController.cs
+++ b/Members/Controllers/ColorsController.cs
@@ -22,8 +22,15 @@ namespace Members.Controllers
         [HttpGet]
         public async Task<ActionResult<Dictionary<string, string>>> GetColors()
         {
-            var colors = await _context.ColorVars.ToListAsync();
-            return colors.ToDictionary(c => c.Name, c => c.Value);
+            try
+            {
+                var colors = await _context.ColorVars.ToListAsync();
+                return colors.GroupBy(c => c.Name).ToDictionary(g => g.Key, g => g.First().Value);
+            }
+            catch (System.Exception)
+            {
+                return new StatusCodeResult(500);
+            }
         }
     }
 }


### PR DESCRIPTION
This commit fixes a bug where the `ColorsController` was throwing a 500 error if there were duplicate keys in the `ColorVars` table. The `GetColors` method has been updated to handle duplicate keys by grouping the colors by name and taking the first value. A `try-catch` block has also been added to the method to handle any other exceptions that may occur.

The following changes were made:

*   **ColorsController.cs:**
    *   Updated the `GetColors` method to handle duplicate keys.
    *   Added a `try-catch` block to the `GetColors` method.