### PR TITLE
feat: Add import and export functionality to color management page

### DIFF
--- a/Members/Areas/Admin/Pages/ColorManagement.cshtml
+++ b/Members/Areas/Admin/Pages/ColorManagement.cshtml
@@ -26,6 +26,8 @@
         </div>
         <div class="text-center mt-4">
             <button type="submit" class="btn btn-sm btn-success rounded-2 shadow"><i class="bi bi-save"></i> Save Colors</button>
+            <button type="submit" asp-page-handler="Export" class="btn btn-sm btn-primary rounded-2 shadow"><i class="bi bi-box-arrow-down"></i> Export Colors</button>
+            <button type="button" class="btn btn-sm btn-info rounded-2 shadow" data-bs-toggle="modal" data-bs-target="#importModal"><i class="bi bi-box-arrow-up"></i> Import Colors</button>
         </div>
     </form>
 </div>
@@ -33,3 +35,26 @@
 @section Scripts {
     <script src="~/js/color-management.js" asp-append-version="true"></script>
 }
+
+<div class="modal fade" id="importModal" tabindex="-1" aria-labelledby="importModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form method="post" asp-page-handler="Import" enctype="multipart/form-data">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="importModalLabel">Import Colors</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="csvFile" class="form-label">Select CSV File</label>
+                        <input class="form-control" type="file" id="csvFile" name="csvFile">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                    <button type="submit" class="btn btn-primary">Import</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/Members/Areas/Admin/Pages/ColorManagement.cshtml.cs
+++ b/Members/Areas/Admin/Pages/ColorManagement.cshtml.cs
@@ -1,10 +1,13 @@
 using Members.Data;
 using Members.Models;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -46,6 +49,59 @@ namespace Members.Areas.Admin.Pages
             }
 
             await _context.SaveChangesAsync();
+
+            return RedirectToPage();
+        }
+
+        public async Task<IActionResult> OnPostExportAsync()
+        {
+            var colors = await _context.ColorVars.ToListAsync();
+            var builder = new StringBuilder();
+            builder.AppendLine("Name,Value");
+            foreach (var color in colors)
+            {
+                builder.AppendLine($"{color.Name},{color.Value}");
+            }
+
+            return File(Encoding.UTF8.GetBytes(builder.ToString()), "text/csv", "colors.csv");
+        }
+
+        public async Task<IActionResult> OnPostImportAsync(IFormFile csvFile)
+        {
+            if (csvFile != null && csvFile.Length > 0)
+            {
+                using (var reader = new StreamReader(csvFile.OpenReadStream()))
+                {
+                    var header = await reader.ReadLineAsync(); // Skip header
+                    while (!reader.EndOfStream)
+                    {
+                        var line = await reader.ReadLineAsync();
+                        if (line != null)
+                        {
+                            var values = line.Split(',');
+                            if (values.Length == 2)
+                            {
+                                var name = values[0];
+                                var value = values[1];
+                                if (Regex.IsMatch(value, @"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"))
+                                {
+                                    var colorVar = await _context.ColorVars.FirstOrDefaultAsync(c => c.Name == name);
+                                    if (colorVar != null)
+                                    {
+                                        colorVar.Value = value;
+                                    }
+                                    else
+                                    {
+                                        _context.ColorVars.Add(new ColorVar { Name = name, Value = value });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                await _context.SaveChangesAsync();
+            }
 
             return RedirectToPage();
         }


### PR DESCRIPTION
This commit adds the ability to import and export colors as a CSV file on the color management page.

The following changes were made:

*   **ColorManagement.cshtml:**
    *   Added buttons for importing and exporting colors.
    *   Added a modal for importing colors.

*   **ColorManagement.cshtml.cs:**
    *   Added `OnPostExportAsync` and `OnPostImportAsync` methods to handle the import and export functionality.
    *   Added null checks to prevent errors when reading the CSV file.