### PR TITLE
fix: Correctly download CSV file

### DIFF
--- a/Members/Areas/Admin/Pages/ColorManagement.cshtml
+++ b/Members/Areas/Admin/Pages/ColorManagement.cshtml
@@ -26,7 +26,7 @@
         </div>
         <div class="text-center mt-4">
             <button type="submit" class="btn btn-sm btn-success rounded-2 shadow"><i class="bi bi-save"></i> Save Colors</button>
-            <button type="submit" asp-page-handler="Export" class="btn btn-sm btn-primary rounded-2 shadow"><i class="bi bi-box-arrow-down"></i> Export Colors</button>
+            <a asp-page-handler="ExportToCsv" class="btn btn-sm btn-primary rounded-2 shadow"><i class="bi bi-box-arrow-down"></i> Export Colors</a>
             <button type="button" class="btn btn-sm btn-info rounded-2 shadow" data-bs-toggle="modal" data-bs-target="#importModal"><i class="bi bi-box-arrow-up"></i> Import Colors</button>
         </div>
     </form>

--- a/Members/Areas/Admin/Pages/ColorManagement.cshtml.cs
+++ b/Members/Areas/Admin/Pages/ColorManagement.cshtml.cs
@@ -53,19 +53,26 @@ namespace Members.Areas.Admin.Pages
             return RedirectToPage();
         }
 
-        public async Task<IActionResult> OnPostExportAsync()
+        public async Task<IActionResult> OnGetExportToCsvAsync()
         {
             var colors = await _context.ColorVars.ToListAsync();
             var builder = new StringBuilder();
             builder.AppendLine("Name,Value");
             foreach (var color in colors)
             {
-                builder.AppendLine($"{color.Name},{color.Value}");
+                builder.AppendLine($"{EscapeCsvField(color.Name)},{EscapeCsvField(color.Value)}");
             }
 
-            var fileName = "colors.csv";
+            var fileName = $"colors_{DateTime.UtcNow:yyyyMMddHHmmss}.csv";
             var buffer = Encoding.UTF8.GetBytes(builder.ToString());
             return File(buffer, "text/csv", fileName);
+        }
+
+        private static string EscapeCsvField(string? field)
+        {
+            if (string.IsNullOrEmpty(field))
+                return string.Empty;
+            return field.Replace("\"", "\"\"");
         }
 
         public async Task<IActionResult> OnPostImportAsync(IFormFile csvFile)


### PR DESCRIPTION
This commit fixes a bug where the CSV file was not being downloaded correctly. The `OnPostExportAsync` method has been replaced with an `OnGetExportToCsvAsync` method that correctly downloads the file. The `ColorManagement.cshtml` file has also been updated to call the new method.

The following changes were made:

*   **ColorManagement.cshtml.cs:**
    *   Replaced the `OnPostExportAsync` method with an `OnGetExportToCsvAsync` method that correctly downloads the file.
    *   Added an `EscapeCsvField` method to ensure that the CSV is formatted correctly.

*   **ColorManagement.cshtml:**
    *   Updated the "Export Colors" button to call the new `OnGetExportToCsvAsync` method.